### PR TITLE
Add 'input based' operations.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ go-jira-ui is an ncurses command line tool for accessing JIRA.
 It is built around the excellent [go-jira](https://github.com/Netflix-Skunkworks/go-jira) and
 [termui](https://github.com/gizak/termui) libraries.
 
+It aims to be similar to familiar tools like vim, tig, and less.
+
 In order to use this, you should configure an 'endpoint' as per the go-jira
 documentation:
 
@@ -32,12 +34,13 @@ This should be all that's needed to get going.
 * Label view of a given query, to see categorisations easily
 * Sorting of queries; supply your own custom sorts
 * View tickets from the query
-* Edit/Comment on tickets from both list and detail view
 * Drill into sub/blocker/related/mentioned tickets in details view
 * Show open tickets in an Epic.
 * Basic compatibility with [go-jira](https://github.com/Netflix-Skunkworks/go-jira) commandline and options loading
+* Label adding/removing
+* Comment, watch, assign and take implemented via :-mode commands
 
-At present, edit and comment will exit after the update. This is a workaround
+At present, edit will exit after the update. This is a workaround
 to an implementation issue, being tracked in [#8](https://github.com/mikepea/go-jira-ui/issues/8)
 
 ### Usage
@@ -60,6 +63,23 @@ Actions:
     C            - Comment on ticket
     S            - Select sort order (query results page only)
 
+Commands (like vim/tig/less):
+
+    :comment {single-line-comment} - add a short comment to ticket
+    :label {labels}                - add labels to selected ticket
+    :label add/remove {labels}     - add/remove labels to selected ticket
+    :take                          - assign ticket to self
+    :assign {user}                 - assign ticket to {user}
+    :unassign                      - unassign ticket
+    :watch                         - watch ticket
+    :<up>                          - select previous command
+    :quit or :q                    - quit
+
+Searching:
+
+    /{regex}                       - search down
+    ?{regex}                       - search up
+
 Navigation:
 
     up/k         - previous line
@@ -68,6 +88,7 @@ Navigation:
     C-b          - previous page
     }            - next paragraph/section/fast-move
     {            - previous paragraph/section/fast-move
+    n            - next search match
     g            - go to top of page
     G            - go to bottom of page
     q            - go back / quit

--- a/README.md
+++ b/README.md
@@ -60,7 +60,6 @@ Actions:
     <enter>      - select query/ticket
     L            - Label view (query results page only)
     E            - Edit ticket
-    C            - Comment on ticket
     S            - Select sort order (query results page only)
 
 Commands (like vim/tig/less):

--- a/base_input_box.go
+++ b/base_input_box.go
@@ -2,25 +2,26 @@ package jiraui
 
 import (
 	ui "github.com/gizak/termui"
-	"strings"
 )
 
 type BaseInputBox struct {
-	eb     *EditBox
+	EditBox
 	uiList *ui.List
 }
 
 func (p *BaseInputBox) Update() {
 	ls := p.uiList
-	ls.Items = strings.Split(string(p.eb.text), "\n")
 	ui.Render(ls)
+}
+
+func (p *BaseInputBox) Id() string {
+	return ""
 }
 
 func (p *BaseInputBox) Create() {
 	ls := ui.NewList()
 	var strs []string
 	p.uiList = ls
-	p.eb = new(EditBox)
 	ls.Items = strs
 	ls.ItemFgColor = ui.ColorGreen
 	ls.BorderFg = ui.ColorRed

--- a/base_input_box.go
+++ b/base_input_box.go
@@ -1,0 +1,33 @@
+package jiraui
+
+import (
+	ui "github.com/gizak/termui"
+	"strings"
+)
+
+type BaseInputBox struct {
+	eb     *EditBox
+	uiList *ui.List
+}
+
+func (p *BaseInputBox) Update() {
+	ls := p.uiList
+	ls.Items = strings.Split(string(p.eb.text), "\n")
+	ui.Render(ls)
+}
+
+func (p *BaseInputBox) Create() {
+	ls := ui.NewList()
+	var strs []string
+	p.uiList = ls
+	p.eb = new(EditBox)
+	ls.Items = strs
+	ls.ItemFgColor = ui.ColorGreen
+	ls.BorderFg = ui.ColorRed
+	ls.Height = 1
+	ls.Width = 30
+	ls.Overflow = "wrap"
+	ls.X = ui.TermWidth()/2 - ls.Width/2
+	ls.Y = ui.TermHeight()/2 - ls.Height/2
+	p.Update()
+}

--- a/base_list_page.go
+++ b/base_list_page.go
@@ -6,6 +6,12 @@ import (
 	"regexp"
 )
 
+type Search struct {
+	command     string
+	directionUp bool
+	re          *regexp.Regexp
+}
+
 type BaseListPage struct {
 	selectedLine     int
 	uiList           *ui.List
@@ -13,6 +19,33 @@ type BaseListPage struct {
 	cachedResults    []string
 	firstDisplayLine int
 	isPopulated      bool
+	ActiveSearch     Search
+}
+
+func (p *BaseListPage) SetSearch(searchCommand string) {
+	if len(searchCommand) < 2 {
+		// must be '/a' minimum
+		return
+	}
+	direction := []byte(searchCommand)[0]
+	regex := "(?i)" + string([]byte(searchCommand)[1:])
+	s := new(Search)
+	s.command = searchCommand
+	if direction == '?' {
+		s.directionUp = true
+	} else if direction == '/' {
+		s.directionUp = false
+	} else {
+		// bad command
+		return
+	}
+	if re, err := regexp.Compile(regex); err != nil {
+		// bad regex
+		return
+	} else {
+		s.re = re
+		p.ActiveSearch = *s
+	}
 }
 
 func (p *BaseListPage) IsPopulated() bool {
@@ -23,14 +56,20 @@ func (p *BaseListPage) IsPopulated() bool {
 	}
 }
 
+func (p *BaseListPage) FixFirstDisplayLine(n int) {
+	if p.selectedLine < p.firstDisplayLine {
+		p.firstDisplayLine = p.selectedLine
+	} else if p.selectedLine > p.lastDisplayedLine() {
+		p.firstDisplayLine = p.selectedLine - (p.PageLines() - 1)
+	}
+}
+
 func (p *BaseListPage) PreviousLine(n int) {
 	p.selectedLine = p.selectedLine - n
 	if p.selectedLine < 0 {
 		p.selectedLine = 0
 	}
-	if p.selectedLine < p.firstDisplayLine {
-		p.firstDisplayLine = p.selectedLine
-	}
+	p.FixFirstDisplayLine(n)
 }
 
 func (p *BaseListPage) NextLine(n int) {
@@ -39,9 +78,7 @@ func (p *BaseListPage) NextLine(n int) {
 	} else {
 		p.selectedLine = len(p.displayLines) - 1
 	}
-	if p.selectedLine > p.lastDisplayedLine() {
-		p.firstDisplayLine = p.firstDisplayLine + n
-	}
+	p.FixFirstDisplayLine(n)
 }
 
 func (p *BaseListPage) PreviousPara() {
@@ -53,11 +90,15 @@ func (p *BaseListPage) NextPara() {
 }
 
 func (p *BaseListPage) PreviousPage() {
-	p.PreviousLine(p.uiList.Height - 2)
+	p.PreviousLine(p.PageLines())
 }
 
 func (p *BaseListPage) NextPage() {
-	p.NextLine(p.uiList.Height - 2)
+	p.NextLine(p.PageLines())
+}
+
+func (p *BaseListPage) PageLines() int {
+	return p.uiList.Height - 2
 }
 
 func (p *BaseListPage) TopOfPage() {
@@ -77,6 +118,13 @@ func (p *BaseListPage) BottomOfPage() {
 
 func (p *BaseListPage) lastDisplayedLine() int {
 	return lastLineDisplayed(p.uiList, p.firstDisplayLine, 3)
+}
+
+func (p *BaseListPage) SetSelectedLine(line int) {
+	if line > 0 && line < len(p.cachedResults) {
+		p.selectedLine = line
+		p.FixFirstDisplayLine(0)
+	}
 }
 
 func (p *BaseListPage) markActiveLine() {

--- a/base_list_page.go
+++ b/base_list_page.go
@@ -12,6 +12,15 @@ type BaseListPage struct {
 	displayLines     []string
 	cachedResults    []string
 	firstDisplayLine int
+	isPopulated      bool
+}
+
+func (p *BaseListPage) IsPopulated() bool {
+	if len(p.cachedResults) > 0 || p.isPopulated {
+		return true
+	} else {
+		return false
+	}
 }
 
 func (p *BaseListPage) PreviousLine(n int) {
@@ -103,8 +112,8 @@ func (p *BaseListPage) Refresh() {
 	pDeref := &p
 	q := *pDeref
 	q.cachedResults = make([]string, 0)
-	q.Create()
 	changePage()
+	q.Create()
 }
 
 func (p *BaseListPage) Create() {

--- a/command_bar.go
+++ b/command_bar.go
@@ -6,11 +6,29 @@ import (
 
 type CommandBar struct {
 	uiList *ui.List
-	text   []byte
+	EditBox
+}
+
+func (p *CommandBar) Submit() {
+	if obj, ok := currentPage.(CommandBoxer); ok {
+		obj.SetCommandMode(false)
+		obj.ExecuteCommand()
+		obj.Update()
+	}
+}
+
+func (p *CommandBar) Reset() {
+	p.text = []byte(``)
+	p.line_voffset = 0
+	p.cursor_boffset = 0
+	p.cursor_voffset = 0
+	p.cursor_coffset = 0
 }
 
 func (p *CommandBar) Update() {
 	ls := p.uiList
+	strs := []string{string(p.text)}
+	ls.Items = strs
 	ui.Render(ls)
 }
 

--- a/command_bar.go
+++ b/command_bar.go
@@ -1,0 +1,27 @@
+package jiraui
+
+import (
+	ui "github.com/gizak/termui"
+)
+
+type CommandBar struct {
+	uiList *ui.List
+	text   []byte
+}
+
+func (p *CommandBar) Update() {
+	ls := p.uiList
+	ui.Render(ls)
+}
+
+func (p *CommandBar) Create() {
+	ls := ui.NewList()
+	p.uiList = ls
+	ls.ItemFgColor = ui.ColorGreen
+	ls.Border = false
+	ls.Height = 1
+	ls.Width = ui.TermWidth()
+	ls.X = 0
+	ls.Y = ui.TermHeight() - 1
+	p.Update()
+}

--- a/command_bar.go
+++ b/command_bar.go
@@ -7,12 +7,24 @@ import (
 type CommandBar struct {
 	uiList *ui.List
 	EditBox
+	previousCommands []string
 }
 
 func (p *CommandBar) Submit() {
 	if obj, ok := currentPage.(CommandBoxer); ok {
 		obj.SetCommandMode(false)
 		obj.ExecuteCommand()
+		obj.Update()
+		p.previousCommands = append(p.previousCommands, string(p.text))
+	}
+}
+
+func (p *CommandBar) PreviousCommand() {
+	if len(p.previousCommands) == 0 {
+		return
+	}
+	if obj, ok := currentPage.(CommandBoxer); ok {
+		p.text = []byte(p.previousCommands[len(p.previousCommands)-1])
 		obj.Update()
 	}
 }

--- a/command_bar_fragment.go
+++ b/command_bar_fragment.go
@@ -51,6 +51,13 @@ func handleCommand(command string) {
 		handleQuit()
 	case action == "label" || action == "labels":
 		handleLabelCommand(args)
+	case action == "assign":
+		handleAssignCommand(args[0])
+	case action == "unassign":
+		handleAssignCommand("-1")
+	case action == "take":
+		opts := getJiraOpts()
+		handleAssignCommand(opts["user"].(string))
 	case action == "comment":
 		handleCommentCommand(string(command[9:]))
 	}
@@ -93,6 +100,19 @@ func handleCommentCommand(comment string) {
 		}
 		log.Debugf("handleCommentCommand: ticket: %s, comment %s", ticketId, comment)
 		runJiraCmdCommentNoEditor(ticketId, comment)
+		obj.Refresh()
+	}
+}
+
+func handleAssignCommand(user string) {
+	log.Debugf("handleAssignCommand: user %s", user)
+	if obj, ok := currentPage.(TicketCommander); ok {
+		ticketId := obj.ActiveTicketId()
+		if ticketId == "" || user == "" {
+			return
+		}
+		log.Debugf("handleAssignCommand: ticket: %s, user %s", ticketId, user)
+		runJiraCmdAssign(ticketId, user)
 		obj.Refresh()
 	}
 }

--- a/command_bar_fragment.go
+++ b/command_bar_fragment.go
@@ -51,6 +51,8 @@ func handleCommand(command string) {
 		handleQuit()
 	case action == "label" || action == "labels":
 		handleLabelCommand(args)
+	case action == "watch":
+		handleWatchCommand(true)
 	case action == "assign":
 		handleAssignCommand(args[0])
 	case action == "unassign":
@@ -113,6 +115,22 @@ func handleAssignCommand(user string) {
 		}
 		log.Debugf("handleAssignCommand: ticket: %s, user %s", ticketId, user)
 		runJiraCmdAssign(ticketId, user)
+		obj.Refresh()
+	}
+}
+
+func handleWatchCommand(mode bool) {
+	log.Debugf("handleWatchCommand: mode %q", mode)
+	if obj, ok := currentPage.(TicketCommander); ok {
+		ticketId := obj.ActiveTicketId()
+		if ticketId == "" {
+			return
+		} else if !mode {
+			log.Errorf("handleAssignCommand: watch == false not yet supported.")
+			return
+		}
+		log.Debugf("handleWatchCommand: ticket: %s, mode %s", ticketId)
+		runJiraCmdWatch(ticketId)
 		obj.Refresh()
 	}
 }

--- a/command_bar_fragment.go
+++ b/command_bar_fragment.go
@@ -1,0 +1,38 @@
+package jiraui
+
+type CommandBarFragment struct {
+	commandBar  *CommandBar
+	commandMode bool
+}
+
+func (p *CommandBarFragment) ExecuteCommand() {
+	command := string(p.commandBar.text)
+	if command == "" {
+		return
+	}
+	commandMode := string([]rune(command)[0])
+	switch commandMode {
+	case "/":
+		log.Debugf("Search down: %q", command)
+	case "?":
+		log.Debugf("Search up: %q", command)
+	case ":":
+		log.Debugf("Search up: %q", command)
+		switch command {
+		case ":q":
+			handleQuit()
+		}
+	}
+}
+
+func (p *CommandBarFragment) SetCommandMode(mode bool) {
+	p.commandMode = mode
+}
+
+func (p *CommandBarFragment) CommandMode() bool {
+	return p.commandMode
+}
+
+func (p *CommandBarFragment) CommandBar() *CommandBar {
+	return p.commandBar
+}

--- a/command_bar_fragment.go
+++ b/command_bar_fragment.go
@@ -1,5 +1,9 @@
 package jiraui
 
+import (
+	"strings"
+)
+
 type CommandBarFragment struct {
 	commandBar  *CommandBar
 	commandMode bool
@@ -14,13 +18,15 @@ func (p *CommandBarFragment) ExecuteCommand() {
 	switch commandMode {
 	case "/":
 		log.Debugf("Search down: %q", command)
+		if obj, ok := currentPage.(Searcher); ok {
+			obj.SetSearch(command)
+			obj.Search()
+		}
 	case "?":
 		log.Debugf("Search up: %q", command)
-	case ":":
-		log.Debugf("Search up: %q", command)
-		switch command {
-		case ":q":
-			handleQuit()
+		if obj, ok := currentPage.(Searcher); ok {
+			obj.SetSearch(command)
+			obj.Search()
 		}
 	}
 }

--- a/command_bar_fragment.go
+++ b/command_bar_fragment.go
@@ -51,6 +51,8 @@ func handleCommand(command string) {
 		handleQuit()
 	case action == "label" || action == "labels":
 		handleLabelCommand(args)
+	case action == "comment":
+		handleCommentCommand(string(command[9:]))
 	}
 }
 
@@ -79,7 +81,19 @@ func handleLabelCommand(args []string) {
 		}
 		runJiraCmdLabels(ticketId, action, labels)
 		obj.Refresh()
+	}
+}
 
+func handleCommentCommand(comment string) {
+	log.Debugf("handleCommentCommand: comment %s", comment)
+	if obj, ok := currentPage.(TicketCommander); ok {
+		ticketId := obj.ActiveTicketId()
+		if ticketId == "" || comment == "" {
+			return
+		}
+		log.Debugf("handleCommentCommand: ticket: %s, comment %s", ticketId, comment)
+		runJiraCmdCommentNoEditor(ticketId, comment)
+		obj.Refresh()
 	}
 }
 

--- a/command_bar_fragment.go
+++ b/command_bar_fragment.go
@@ -1,7 +1,6 @@
 package jiraui
 
 import (
-	"github.com/Netflix-Skunkworks/go-jira"
 	"strings"
 )
 
@@ -57,8 +56,7 @@ func handleCommand(command string) {
 
 func handleLabelCommand(args []string) {
 	log.Debugf("handleLabelCommand: args %s", args)
-	if obj, ok := currentPage.(ActiveTicketIder); ok {
-		opts := getJiraOpts()
+	if obj, ok := currentPage.(TicketCommander); ok {
 		ticketId := obj.ActiveTicketId()
 		if ticketId == "" || args == nil {
 			return
@@ -79,12 +77,9 @@ func handleLabelCommand(args []string) {
 		default:
 			labels = args
 		}
-		log.Noticef("handleLabelCommand: CmdLabels(%q, %q, %s)", action, ticketId, labels)
-		c := jira.New(opts)
-		err := c.CmdLabels(action, ticketId, labels)
-		if err != nil {
-			log.Errorf("Error writing labels: %q", err)
-		}
+		runJiraCmdLabels(ticketId, action, labels)
+		obj.Refresh()
+
 	}
 }
 

--- a/editbox.go
+++ b/editbox.go
@@ -1,0 +1,108 @@
+package jiraui
+
+import (
+	"unicode/utf8"
+)
+
+const tabstop_length = 8
+
+type EditBox struct {
+	text           []byte
+	line_voffset   int
+	cursor_boffset int // cursor offset in bytes
+	cursor_voffset int // visual cursor offset in termbox cells
+	cursor_coffset int // cursor offset in unicode code points
+}
+
+func byte_slice_grow(s []byte, desired_cap int) []byte {
+	if cap(s) < desired_cap {
+		ns := make([]byte, len(s), desired_cap)
+		copy(ns, s)
+		return ns
+	}
+	return s
+}
+
+func byte_slice_remove(text []byte, from, to int) []byte {
+	size := to - from
+	copy(text[from:], text[to:])
+	text = text[:len(text)-size]
+	return text
+}
+
+func byte_slice_insert(text []byte, offset int, what []byte) []byte {
+	n := len(text) + len(what)
+	text = byte_slice_grow(text, n)
+	text = text[:n]
+	copy(text[offset+len(what):], text[offset:])
+	copy(text[offset:], what)
+	return text
+}
+
+func decodeTermuiKbdStringToRune(str string) rune {
+	r, _ := utf8.DecodeRuneInString(str) // should be a single rune
+	return r
+}
+
+func (eb *EditBox) InsertRune(r rune) {
+	var buf [utf8.UTFMax]byte
+	n := utf8.EncodeRune(buf[:], r)
+	eb.text = byte_slice_insert(eb.text, eb.cursor_boffset, buf[:n])
+	eb.MoveCursorOneRuneForward()
+}
+
+func (eb *EditBox) DeleteRuneBackward() {
+	if eb.cursor_boffset == 0 {
+		return
+	}
+	eb.MoveCursorOneRuneBackward()
+	_, size := eb.RuneUnderCursor()
+	eb.text = byte_slice_remove(eb.text, eb.cursor_boffset, eb.cursor_boffset+size)
+}
+
+func (eb *EditBox) MoveCursorOneRuneBackward() {
+	if eb.cursor_boffset == 0 {
+		return
+	}
+	_, size := eb.RuneBeforeCursor()
+	eb.MoveCursorTo(eb.cursor_boffset - size)
+}
+
+func (eb *EditBox) MoveCursorOneRuneForward() {
+	if eb.cursor_boffset == len(eb.text) {
+		return
+	}
+	_, size := eb.RuneUnderCursor()
+	eb.MoveCursorTo(eb.cursor_boffset + size)
+}
+
+func (eb *EditBox) RuneUnderCursor() (rune, int) {
+	return utf8.DecodeRune(eb.text[eb.cursor_boffset:])
+}
+
+func (eb *EditBox) RuneBeforeCursor() (rune, int) {
+	return utf8.DecodeLastRune(eb.text[:eb.cursor_boffset])
+}
+
+func (eb *EditBox) MoveCursorTo(boffset int) {
+	eb.cursor_boffset = boffset
+	eb.cursor_voffset, eb.cursor_coffset = voffset_coffset(eb.text, boffset)
+}
+
+func rune_advance_len(r rune, pos int) int {
+	if r == '\t' {
+		return tabstop_length - pos%tabstop_length
+	}
+	return 1
+}
+
+func voffset_coffset(text []byte, boffset int) (voffset, coffset int) {
+	text = text[:boffset]
+	for len(text) > 0 {
+		r, size := utf8.DecodeRune(text)
+		text = text[size:]
+		coffset += 1
+		voffset += rune_advance_len(r, voffset)
+	}
+	return
+}

--- a/label_list_page.go
+++ b/label_list_page.go
@@ -73,6 +73,7 @@ func (p *LabelListPage) Create() {
 	queryJQL := p.ActiveQuery.JQL
 	p.labelCounts = countLabelsFromQuery(queryJQL)
 	p.cachedResults = p.labelsAsSortedList()
+	p.isPopulated = true
 	p.displayLines = make([]string, len(p.cachedResults))
 	ls.ItemFgColor = ui.ColorYellow
 	ls.BorderLabel = fmt.Sprintf("Label view -- %s: %s", queryName, queryJQL)

--- a/label_list_page.go
+++ b/label_list_page.go
@@ -7,6 +7,8 @@ import (
 
 type LabelListPage struct {
 	BaseListPage
+	CommandBarFragment
+	StatusBarFragment
 	labelCounts map[string]int
 	ActiveQuery Query
 }
@@ -53,12 +55,20 @@ func (p *LabelListPage) Update() {
 	p.markActiveLine()
 	ls.Items = p.displayLines[p.firstDisplayLine:]
 	ui.Render(ls)
+	p.statusBar.Update()
+	p.commandBar.Update()
 }
 
 func (p *LabelListPage) Create() {
 	ui.Clear()
 	ls := ui.NewList()
 	p.uiList = ls
+	if p.statusBar == nil {
+		p.statusBar = new(StatusBar)
+	}
+	if p.commandBar == nil {
+		p.commandBar = new(CommandBar)
+	}
 	queryName := p.ActiveQuery.Name
 	queryJQL := p.ActiveQuery.JQL
 	p.labelCounts = countLabelsFromQuery(queryJQL)
@@ -66,8 +76,10 @@ func (p *LabelListPage) Create() {
 	p.displayLines = make([]string, len(p.cachedResults))
 	ls.ItemFgColor = ui.ColorYellow
 	ls.BorderLabel = fmt.Sprintf("Label view -- %s: %s", queryName, queryJQL)
-	ls.Height = ui.TermHeight()
+	ls.Height = ui.TermHeight() - 2
 	ls.Width = ui.TermWidth()
 	ls.Y = 0
+	p.statusBar.Create()
+	p.commandBar.Create()
 	p.Update()
 }

--- a/label_list_page.go
+++ b/label_list_page.go
@@ -13,6 +13,28 @@ type LabelListPage struct {
 	ActiveQuery Query
 }
 
+func (p *LabelListPage) Search() {
+	s := p.ActiveSearch
+	n := len(p.cachedResults)
+	if s.command == "" {
+		return
+	}
+	increment := 1
+	if s.directionUp {
+		increment = -1
+	}
+	// we use modulo here so we can loop through every line.
+	// adding 'n' means we never have '-1 % n'.
+	startLine := (p.selectedLine + n + increment) % n
+	for i := startLine; i != p.selectedLine; i = (i + increment + n) % n {
+		if s.re.MatchString(p.cachedResults[i]) {
+			p.SetSelectedLine(i)
+			p.Update()
+			break
+		}
+	}
+}
+
 func (p *LabelListPage) labelsAsSortedList() []string {
 	return sortedKeys(p.labelCounts)
 }

--- a/password_box.go
+++ b/password_box.go
@@ -1,0 +1,31 @@
+package jiraui
+
+import (
+	ui "github.com/gizak/termui"
+	"strings"
+)
+
+type PasswordInputBox struct {
+	BaseInputBox
+}
+
+func (p *PasswordInputBox) Update() {
+	ls := p.uiList
+	ls.Items = strings.Split(string(p.eb.text), "\n")
+	ui.Render(ls)
+}
+
+func (p *PasswordInputBox) Create() {
+	ls := ui.NewList()
+	p.uiList = ls
+	var strs []string
+	ls.Items = strs
+	ls.ItemFgColor = ui.ColorGreen
+	ls.BorderLabel = "Enter Password:"
+	ls.BorderFg = ui.ColorRed
+	ls.Height = 1
+	ls.Width = 30
+	ls.X = ui.TermWidth()/2 - ls.Width/2
+	ls.Y = ui.TermHeight()/2 - ls.Height/2
+	p.Update()
+}

--- a/password_input_box.go
+++ b/password_input_box.go
@@ -11,7 +11,7 @@ type PasswordInputBox struct {
 
 func (p *PasswordInputBox) Update() {
 	ls := p.uiList
-	ls.Items = strings.Split(string(p.eb.text), "\n")
+	ls.Items = strings.Split(string(p.text), "\n")
 	ui.Render(ls)
 }
 
@@ -23,7 +23,7 @@ func (p *PasswordInputBox) Create() {
 	ls.ItemFgColor = ui.ColorGreen
 	ls.BorderLabel = "Enter Password:"
 	ls.BorderFg = ui.ColorRed
-	ls.Height = 1
+	ls.Height = 3
 	ls.Width = 30
 	ls.X = ui.TermWidth()/2 - ls.Width/2
 	ls.Y = ui.TermHeight()/2 - ls.Height/2

--- a/query_list_page.go
+++ b/query_list_page.go
@@ -13,10 +13,9 @@ type Query struct {
 
 type QueryPage struct {
 	BaseListPage
+	CommandBarFragment
+	StatusBarFragment
 	cachedResults []Query
-	statusBar     *StatusBar
-	commandBar    *CommandBar
-	commandMode   bool
 }
 
 var baseQueries = []Query{
@@ -49,36 +48,7 @@ func getQueries() (queries []Query) {
 	return append(baseQueries, queries...)
 }
 
-func (p *QueryPage) ExecuteCommand() {
-	command := string(p.commandBar.text)
-	commandMode := string([]rune(command)[0])
-	switch commandMode {
-	case "/":
-		log.Debugf("Search down: %q", command)
-	case "?":
-		log.Debugf("Search up: %q", command)
-	case ":":
-		log.Debugf("Search up: %q", command)
-		switch command {
-		case ":q":
-			handleQuit()
-		}
-	default:
-		log.Errorf("Unknown Command: %q - bailing", command)
-		handleQuit()
 	}
-}
-
-func (p *QueryPage) SetCommandMode(mode bool) {
-	p.commandMode = mode
-}
-
-func (p *QueryPage) CommandMode() bool {
-	return p.commandMode
-}
-
-func (p *QueryPage) CommandBar() *CommandBar {
-	return p.commandBar
 }
 
 func (p *QueryPage) markActiveLine() {

--- a/query_list_page.go
+++ b/query_list_page.go
@@ -14,6 +14,7 @@ type Query struct {
 type QueryPage struct {
 	BaseListPage
 	cachedResults []Query
+	statusBar     *StatusBar
 }
 
 var baseQueries = []Query{
@@ -116,6 +117,7 @@ func (p *QueryPage) Update() {
 	p.markActiveLine()
 	ls.Items = p.displayLines[p.firstDisplayLine:]
 	ui.Render(ls)
+	p.statusBar.Update()
 }
 
 func (p *QueryPage) Refresh() {
@@ -130,12 +132,14 @@ func (p *QueryPage) Create() {
 	ui.Clear()
 	ls := ui.NewList()
 	p.uiList = ls
+	p.statusBar = new(StatusBar)
 	p.cachedResults = getQueries()
 	p.displayLines = make([]string, len(p.cachedResults))
 	ls.ItemFgColor = ui.ColorYellow
 	ls.BorderLabel = "Queries"
-	ls.Height = ui.TermHeight()
+	ls.Height = ui.TermHeight() - 2
 	ls.Width = ui.TermWidth()
 	ls.Y = 0
+	p.statusBar.Create()
 	p.Update()
 }

--- a/query_list_page.go
+++ b/query_list_page.go
@@ -48,11 +48,42 @@ func getQueries() (queries []Query) {
 	return append(baseQueries, queries...)
 }
 
+func (p *QueryPage) Search() {
+	s := p.ActiveSearch
+	log.Noticef("QueryPage: search! %q", s.command)
+	n := len(p.cachedResults)
+	if s.command == "" {
+		return
+	}
+	increment := 1
+	if s.directionUp {
+		increment = -1
+	}
+	// we use modulo here so we can loop through every line.
+	// adding 'n' means we never have '-1 % n'.
+	startLine := (p.selectedLine + n + increment) % n
+	for i := startLine; i != p.selectedLine; i = (i + increment + n) % n {
+		if s.re.MatchString(p.cachedResults[i].Name) {
+			log.Noticef("Match found, line %d", i)
+			p.SetSelectedLine(i)
+			p.Update()
+			break
+		}
+	}
+}
+
 func (p *QueryPage) IsPopulated() bool {
 	if len(p.cachedResults) > 0 {
 		return true
 	} else {
 		return false
+	}
+}
+
+func (p *QueryPage) SetSelectedLine(line int) {
+	if line > 0 && line < len(p.cachedResults) {
+		p.selectedLine = line
+		p.FixFirstDisplayLine(0)
 	}
 }
 

--- a/query_list_page.go
+++ b/query_list_page.go
@@ -48,6 +48,11 @@ func getQueries() (queries []Query) {
 	return append(baseQueries, queries...)
 }
 
+func (p *QueryPage) IsPopulated() bool {
+	if len(p.cachedResults) > 0 {
+		return true
+	} else {
+		return false
 	}
 }
 
@@ -129,8 +134,8 @@ func (p *QueryPage) Refresh() {
 	pDeref := &p
 	q := *pDeref
 	q.cachedResults = make([]Query, 0)
-	q.Create()
 	changePage()
+	q.Create()
 }
 
 func (p *QueryPage) Create() {

--- a/query_list_page.go
+++ b/query_list_page.go
@@ -61,9 +61,9 @@ func (p *QueryPage) markActiveLine() {
 		selected := ""
 		if i == p.selectedLine {
 			selected = "fg-white,bg-blue"
-			p.displayLines[i] = fmt.Sprintf("[%-30s -- %s](%s)", v.Name, v.JQL, selected)
+			p.displayLines[i] = fmt.Sprintf("[%-50s | %s](%s)", v.Name, v.JQL, selected)
 		} else {
-			p.displayLines[i] = fmt.Sprintf("%-30s -- %s", v.Name, v.JQL)
+			p.displayLines[i] = fmt.Sprintf("%-50s [|](fg-blue) [%s](fg-green)", v.Name, v.JQL)
 		}
 	}
 }

--- a/query_list_page.go
+++ b/query_list_page.go
@@ -15,6 +15,7 @@ type QueryPage struct {
 	BaseListPage
 	cachedResults []Query
 	statusBar     *StatusBar
+	commandBar    *CommandBar
 }
 
 var baseQueries = []Query{
@@ -133,6 +134,7 @@ func (p *QueryPage) Create() {
 	ls := ui.NewList()
 	p.uiList = ls
 	p.statusBar = new(StatusBar)
+	p.commandBar = new(CommandBar)
 	p.cachedResults = getQueries()
 	p.displayLines = make([]string, len(p.cachedResults))
 	ls.ItemFgColor = ui.ColorYellow
@@ -141,5 +143,6 @@ func (p *QueryPage) Create() {
 	ls.Width = ui.TermWidth()
 	ls.Y = 0
 	p.statusBar.Create()
+	p.commandBar.Create()
 	p.Update()
 }

--- a/run.go
+++ b/run.go
@@ -55,6 +55,7 @@ type PagePager interface {
 	PreviousPage()
 	TopOfPage()
 	BottomOfPage()
+	IsPopulated() bool
 	Update()
 }
 

--- a/run.go
+++ b/run.go
@@ -18,6 +18,14 @@ type EditPager interface {
 	Create()
 }
 
+type CommandBoxer interface {
+	SetCommandMode(bool)
+	ExecuteCommand()
+	CommandMode() bool
+	CommandBar() *CommandBar
+	Update()
+}
+
 type GoBacker interface {
 	GoBack()
 }

--- a/run.go
+++ b/run.go
@@ -18,6 +18,11 @@ type EditPager interface {
 	Create()
 }
 
+type Searcher interface {
+	SetSearch(string)
+	Search()
+}
+
 type CommandBoxer interface {
 	SetCommandMode(bool)
 	ExecuteCommand()

--- a/run.go
+++ b/run.go
@@ -18,6 +18,13 @@ const (
 
 var exitNow = false
 
+type EditPager interface {
+	DeleteRuneBackward()
+	InsertRune(r rune)
+	Update()
+	Create()
+}
+
 type GoBacker interface {
 	GoBack()
 }

--- a/run.go
+++ b/run.go
@@ -60,10 +60,6 @@ type PagePager interface {
 type Navigable interface {
 	Create()
 	Update()
-	PreviousLine(int)
-	NextLine(int)
-	PreviousPage()
-	NextPage()
 	Id() string
 }
 
@@ -73,6 +69,7 @@ var ticketQueryPage *QueryPage
 var ticketListPage *TicketListPage
 var labelListPage *LabelListPage
 var sortOrderPage *SortOrderPage
+var passwordInputBox *PasswordInputBox
 
 func changePage() {
 	switch currentPage.(type) {
@@ -146,8 +143,10 @@ Query Options:
 	}
 
 	jiraCommands := map[string]string{
-		"list": "list",
-		"ls":   "list",
+		"list":     "list",
+		"ls":       "list",
+		"password": "password",
+		"passwd":   "password",
 	}
 
 	cliOpts = make(map[string]interface{})
@@ -213,6 +212,7 @@ Query Options:
 	registerKeyboardHandlers()
 
 	ticketQueryPage = new(QueryPage)
+	passwordInputBox = new(PasswordInputBox)
 
 	switch command {
 	case "list":
@@ -232,6 +232,8 @@ Query Options:
 		currentPage = p
 	case "toplevel":
 		currentPage = ticketQueryPage
+	case "password":
+		currentPage = passwordInputBox
 	default:
 		log.Error("Unknown command %s", command)
 		os.Exit(1)

--- a/run.go
+++ b/run.go
@@ -210,7 +210,7 @@ Query Options:
 		}
 	}
 
-	if !cliOpts["skip_login"].(bool) {
+	if val, ok := cliOpts["skip_login"]; !ok || !val.(bool) {
 		err = ensureLoggedIntoJira()
 		if err != nil {
 			log.Error("Login failed. Aborting")

--- a/run.go
+++ b/run.go
@@ -18,6 +18,10 @@ type EditPager interface {
 	Create()
 }
 
+type ActiveTicketIder interface {
+	ActiveTicketId() string
+}
+
 type Searcher interface {
 	SetSearch(string)
 	Search()

--- a/run.go
+++ b/run.go
@@ -121,6 +121,7 @@ General Options:
   -h --help           Show this usage
   -u --user=USER      Username to use for authenticaion
   -v --verbose        Increase output logging
+  --skiplogin         Skip the login check. You must have a valid session token (eg via 'jira login')
   --version           Print version
 
 Ticket View Options:
@@ -162,6 +163,7 @@ Query Options:
 		"f|queryfields=s": setopt,
 		"t|template=s":    setopt,
 		"m|max_wrap=i":    setopt,
+		"skip_login":      setopt,
 	})
 
 	if err := op.ProcessAll(os.Args[1:]); err != nil {
@@ -190,10 +192,12 @@ Query Options:
 		}
 	}
 
-	err = ensureLoggedIntoJira()
-	if err != nil {
-		log.Error("Login failed. Aborting")
-		os.Exit(2)
+	if !cliOpts["skip_login"].(bool) {
+		err = ensureLoggedIntoJira()
+		if err != nil {
+			log.Error("Login failed. Aborting")
+			os.Exit(2)
+		}
 	}
 
 	err = ui.Init()

--- a/run.go
+++ b/run.go
@@ -18,8 +18,9 @@ type EditPager interface {
 	Create()
 }
 
-type ActiveTicketIder interface {
+type TicketCommander interface {
 	ActiveTicketId() string
+	Refresh()
 }
 
 type Searcher interface {

--- a/sort_order_page.go
+++ b/sort_order_page.go
@@ -45,6 +45,14 @@ func getSorts() (sorts []Sort) {
 	return append(baseSorts, sorts...)
 }
 
+func (p *SortOrderPage) IsPopulated() bool {
+	if len(p.cachedResults) > 0 {
+		return true
+	} else {
+		return false
+	}
+}
+
 func (p *SortOrderPage) markActiveLine() {
 	for i, v := range p.cachedResults {
 		selected := ""
@@ -122,8 +130,8 @@ func (p *SortOrderPage) Refresh() {
 	pDeref := &p
 	q := *pDeref
 	q.cachedResults = make([]Sort, 0)
-	q.Create()
 	changePage()
+	q.Create()
 }
 
 func (p *SortOrderPage) Create() {

--- a/status_bar.go
+++ b/status_bar.go
@@ -1,0 +1,35 @@
+package jiraui
+
+import (
+	ui "github.com/gizak/termui"
+)
+
+type StatusBar struct {
+	uiList *ui.List
+	lines  []string
+}
+
+func (p *StatusBar) StatusLines() []string {
+	return p.lines
+}
+
+func (p *StatusBar) Update() {
+	ls := p.uiList
+	ls.Items = p.StatusLines()
+	ui.Render(ls)
+}
+
+func (p *StatusBar) Create() {
+	ls := ui.NewList()
+	p.uiList = ls
+	p.lines = append(p.lines, "STATUS BAR... STATUS BAR... STATUS BAR...")
+	ls.ItemFgColor = ui.ColorWhite
+	ls.ItemBgColor = ui.ColorRed
+	ls.Bg = ui.ColorRed
+	ls.Border = false
+	ls.Height = 1
+	ls.Width = ui.TermWidth()
+	ls.X = 0
+	ls.Y = ui.TermHeight() - 2
+	p.Update()
+}

--- a/status_bar.go
+++ b/status_bar.go
@@ -22,7 +22,6 @@ func (p *StatusBar) Update() {
 func (p *StatusBar) Create() {
 	ls := ui.NewList()
 	p.uiList = ls
-	p.lines = append(p.lines, "STATUS BAR... STATUS BAR... STATUS BAR...")
 	ls.ItemFgColor = ui.ColorWhite
 	ls.ItemBgColor = ui.ColorRed
 	ls.Bg = ui.ColorRed

--- a/status_bar_fragment.go
+++ b/status_bar_fragment.go
@@ -1,0 +1,5 @@
+package jiraui
+
+type StatusBarFragment struct {
+	statusBar *StatusBar
+}

--- a/templates.go
+++ b/templates.go
@@ -1,7 +1,7 @@
 package jiraui
 
 const (
-	default_list_template = `{{ range .issues }}{{ .key | printf "%-20s"}}  {{ dateFormat "2006-01-02" .fields.created }}/{{ dateFormat "2006-01-02T15:04" .fields.updated }}  {{ .fields.summary | printf "%-75s"}} -- labels({{ join "," .fields.labels }})
+	default_list_template = `{{ range .issues }}[{{ .key | printf "%-12s"}}](fg-red)  [{{ if .fields.assignee }}{{ .fields.assignee.name | printf "%-10s" }}{{else}}{{"Unassigned"| printf "%-10s" }}{{end}} ](fg-blue) [{{ .fields.status.name | printf "%-12s"}}](fg-blue) [{{ dateFormat "2006-01-02" .fields.created }}](fg-blue)/[{{ dateFormat "2006-01-02T15:04" .fields.updated }}](fg-green)  {{ .fields.summary | printf "%-75s"}}
 {{ end }}`
 	default_view_template = `
 issue: [{{ .key }}](fg-red)

--- a/ticket_list_page.go
+++ b/ticket_list_page.go
@@ -6,49 +6,34 @@ import (
 	"regexp"
 )
 
-type Search struct {
-	command     string
-	directionUp bool
-	re          *regexp.Regexp
-}
-
 type TicketListPage struct {
 	BaseListPage
 	CommandBarFragment
 	StatusBarFragment
-	ActiveQuery  Query
-	ActiveSort   Sort
-	ActiveSearch Search
-}
-
-func (p *TicketListPage) SetSearch(searchCommand string) {
-	if len(searchCommand) < 2 {
-		// must be '/a' minimum
-		return
-	}
-	direction := []byte(searchCommand)[0]
-	regex := string([]byte(searchCommand)[1:])
-	s := new(Search)
-	s.command = searchCommand
-	if direction == '?' {
-		s.directionUp = true
-	} else if direction == '/' {
-		s.directionUp = false
-	} else {
-		// bad command
-		return
-	}
-	if re, err := regexp.Compile(regex); err != nil {
-		// bad regex
-		return
-	} else {
-		s.re = re
-		p.ActiveSearch = *s
-	}
+	ActiveQuery Query
+	ActiveSort  Sort
 }
 
 func (p *TicketListPage) Search() {
-	return
+	s := p.ActiveSearch
+	n := len(p.cachedResults)
+	if s.command == "" {
+		return
+	}
+	increment := 1
+	if s.directionUp {
+		increment = -1
+	}
+	// we use modulo here so we can loop through every line.
+	// adding 'n' means we never have '-1 % n'.
+	startLine := (p.selectedLine + n + increment) % n
+	for i := startLine; i != p.selectedLine; i = (i + increment + n) % n {
+		if s.re.MatchString(p.cachedResults[i]) {
+			p.SetSelectedLine(i)
+			p.Update()
+			break
+		}
+	}
 }
 
 func (p *TicketListPage) ActiveTicketId() string {

--- a/ticket_list_page.go
+++ b/ticket_list_page.go
@@ -6,12 +6,49 @@ import (
 	"regexp"
 )
 
+type Search struct {
+	command     string
+	directionUp bool
+	re          *regexp.Regexp
+}
+
 type TicketListPage struct {
 	BaseListPage
 	CommandBarFragment
 	StatusBarFragment
-	ActiveQuery Query
-	ActiveSort  Sort
+	ActiveQuery  Query
+	ActiveSort   Sort
+	ActiveSearch Search
+}
+
+func (p *TicketListPage) SetSearch(searchCommand string) {
+	if len(searchCommand) < 2 {
+		// must be '/a' minimum
+		return
+	}
+	direction := []byte(searchCommand)[0]
+	regex := string([]byte(searchCommand)[1:])
+	s := new(Search)
+	s.command = searchCommand
+	if direction == '?' {
+		s.directionUp = true
+	} else if direction == '/' {
+		s.directionUp = false
+	} else {
+		// bad command
+		return
+	}
+	if re, err := regexp.Compile(regex); err != nil {
+		// bad regex
+		return
+	} else {
+		s.re = re
+		p.ActiveSearch = *s
+	}
+}
+
+func (p *TicketListPage) Search() {
+	return
 }
 
 func (p *TicketListPage) GetSelectedTicketId() string {

--- a/ticket_list_page.go
+++ b/ticket_list_page.go
@@ -24,8 +24,8 @@ func (p *TicketListPage) SelectItem() {
 	}
 	q := new(TicketShowPage)
 	q.TicketId = p.GetSelectedTicketId()
-	q.Create()
 	currentPage = q
+	q.Create()
 	changePage()
 }
 

--- a/ticket_list_page.go
+++ b/ticket_list_page.go
@@ -88,6 +88,15 @@ func (p *TicketListPage) Update() {
 	p.commandBar.Update()
 }
 
+func (p *TicketListPage) Refresh() {
+	pDeref := &p
+	q := *pDeref
+	q.cachedResults = make([]string, 0)
+	ticketListPage = q
+	changePage()
+	q.Create()
+}
+
 func (p *TicketListPage) Create() {
 	ui.Clear()
 	ls := ui.NewList()

--- a/ticket_list_page.go
+++ b/ticket_list_page.go
@@ -64,10 +64,6 @@ func (p *TicketListPage) EditTicket() {
 	runJiraCmdEdit(p.GetSelectedTicketId())
 }
 
-func (p *TicketListPage) CommentTicket() {
-	runJiraCmdComment(p.GetSelectedTicketId())
-}
-
 func (p *TicketListPage) Update() {
 	ls := p.uiList
 	p.markActiveLine()

--- a/ticket_list_page.go
+++ b/ticket_list_page.go
@@ -8,6 +8,8 @@ import (
 
 type TicketListPage struct {
 	BaseListPage
+	CommandBarFragment
+	StatusBarFragment
 	ActiveQuery Query
 	ActiveSort  Sort
 }
@@ -40,10 +42,25 @@ func (p *TicketListPage) CommentTicket() {
 	runJiraCmdComment(p.GetSelectedTicketId())
 }
 
+func (p *TicketListPage) Update() {
+	ls := p.uiList
+	p.markActiveLine()
+	ls.Items = p.displayLines[p.firstDisplayLine:]
+	ui.Render(ls)
+	p.statusBar.Update()
+	p.commandBar.Update()
+}
+
 func (p *TicketListPage) Create() {
 	ui.Clear()
 	ls := ui.NewList()
 	p.uiList = ls
+	if p.statusBar == nil {
+		p.statusBar = new(StatusBar)
+	}
+	if p.commandBar == nil {
+		p.commandBar = new(CommandBar)
+	}
 	query := p.ActiveQuery.JQL
 	if sort := p.ActiveSort.JQL; sort != "" {
 		re := regexp.MustCompile(`(?i)\s+ORDER\s+BY.+$`)
@@ -55,8 +72,10 @@ func (p *TicketListPage) Create() {
 	p.displayLines = make([]string, len(p.cachedResults))
 	ls.ItemFgColor = ui.ColorYellow
 	ls.BorderLabel = fmt.Sprintf("%s: %s", p.ActiveQuery.Name, p.ActiveQuery.JQL)
-	ls.Height = ui.TermHeight()
+	ls.Height = ui.TermHeight() - 2
 	ls.Width = ui.TermWidth()
 	ls.Y = 0
+	p.statusBar.Create()
+	p.commandBar.Create()
 	p.Update()
 }

--- a/ticket_list_page.go
+++ b/ticket_list_page.go
@@ -51,6 +51,10 @@ func (p *TicketListPage) Search() {
 	return
 }
 
+func (p *TicketListPage) ActiveTicketId() string {
+	return p.GetSelectedTicketId()
+}
+
 func (p *TicketListPage) GetSelectedTicketId() string {
 	return findTicketIdInString(p.cachedResults[p.selectedLine])
 }

--- a/ticket_show_page.go
+++ b/ticket_show_page.go
@@ -23,6 +23,28 @@ type TicketShowPage struct {
 	opts         map[string]interface{}
 }
 
+func (p *TicketShowPage) Search() {
+	s := p.ActiveSearch
+	n := len(p.cachedResults)
+	if s.command == "" {
+		return
+	}
+	increment := 1
+	if s.directionUp {
+		increment = -1
+	}
+	// we use modulo here so we can loop through every line.
+	// adding 'n' means we never have '-1 % n'.
+	startLine := (p.selectedLine + n + increment) % n
+	for i := startLine; i != p.selectedLine; i = (i + increment + n) % n {
+		if s.re.MatchString(p.cachedResults[i]) {
+			p.SetSelectedLine(i)
+			p.Update()
+			break
+		}
+	}
+}
+
 func (p *TicketShowPage) SelectItem() {
 	selected := p.cachedResults[p.selectedLine]
 	if ok, _ := regexp.MatchString(`^epic_links:`, selected); ok {

--- a/ticket_show_page.go
+++ b/ticket_show_page.go
@@ -99,6 +99,10 @@ func (p *TicketShowPage) CommentTicket() {
 	runJiraCmdComment(p.TicketId)
 }
 
+func (p *TicketShowPage) ActiveTicketId() string {
+	return p.TicketId
+}
+
 func (p *TicketShowPage) ticketTrailAsString() (trail string) {
 	for i := len(p.TicketTrail) - 1; i >= 0; i-- {
 		q := *p.TicketTrail[i]

--- a/ticket_show_page.go
+++ b/ticket_show_page.go
@@ -117,10 +117,6 @@ func (p *TicketShowPage) EditTicket() {
 	runJiraCmdEdit(p.TicketId)
 }
 
-func (p *TicketShowPage) CommentTicket() {
-	runJiraCmdComment(p.TicketId)
-}
-
 func (p *TicketShowPage) ActiveTicketId() string {
 	return p.TicketId
 }

--- a/ticket_show_page.go
+++ b/ticket_show_page.go
@@ -12,6 +12,8 @@ const (
 
 type TicketShowPage struct {
 	BaseListPage
+	CommandBarFragment
+	StatusBarFragment
 	MaxWrapWidth uint
 	TicketId     string
 	Template     string
@@ -114,6 +116,15 @@ func (p *TicketShowPage) Refresh() {
 	changePage()
 }
 
+func (p *TicketShowPage) Update() {
+	ls := p.uiList
+	p.markActiveLine()
+	ls.Items = p.displayLines[p.firstDisplayLine:]
+	ui.Render(ls)
+	p.statusBar.Update()
+	p.commandBar.Update()
+}
+
 func (p *TicketShowPage) Create() {
 	p.opts = getJiraOpts()
 	if p.TicketId == "" {
@@ -128,6 +139,12 @@ func (p *TicketShowPage) Create() {
 	}
 	ui.Clear()
 	ls := ui.NewList()
+	if p.statusBar == nil {
+		p.statusBar = new(StatusBar)
+	}
+	if p.commandBar == nil {
+		p.commandBar = new(CommandBar)
+	}
 	p.uiList = ls
 	if p.Template == "" {
 		if templateOpt := p.opts["template"]; templateOpt == nil {
@@ -148,10 +165,12 @@ func (p *TicketShowPage) Create() {
 	p.cachedResults = WrapText(JiraTicketAsStrings(p.apiBody, p.Template), p.WrapWidth)
 	p.displayLines = make([]string, len(p.cachedResults))
 	ls.ItemFgColor = ui.ColorYellow
-	ls.Height = ui.TermHeight()
+	ls.Height = ui.TermHeight() - 2
 	ls.Width = ui.TermWidth()
 	ls.Border = true
 	ls.BorderLabel = fmt.Sprintf("%s %s", p.TicketId, p.ticketTrailAsString())
 	ls.Y = 0
+	p.statusBar.Create()
+	p.commandBar.Create()
 	p.Update()
 }

--- a/ticket_show_page.go
+++ b/ticket_show_page.go
@@ -112,8 +112,9 @@ func (p *TicketShowPage) Refresh() {
 	q := *pDeref
 	q.cachedResults = make([]string, 0)
 	q.apiBody = nil
-	q.Create()
+	currentPage = q
 	changePage()
+	q.Create()
 }
 
 func (p *TicketShowPage) Update() {

--- a/ui_controls.go
+++ b/ui_controls.go
@@ -238,6 +238,9 @@ func handleAnyKey(e ui.Event) {
 		if key == "<enter>" {
 			cb.Submit()
 			return
+		} else if key == "<up>" {
+			cb.PreviousCommand()
+			return
 		} else {
 			handleEditBoxKey(cb, key)
 			return

--- a/ui_controls.go
+++ b/ui_controls.go
@@ -216,7 +216,7 @@ func handleEditBoxKey(obj EditPager, key string) {
 
 func handleAnyKey(e ui.Event) {
 	key := e.Data.(ui.EvtKbd).KeyStr
-	if obj, ok := currentPage.(PagePager); ok {
+	if obj, ok := currentPage.(PagePager); ok && obj.IsPopulated() {
 		if obj, ok := obj.(CommandBoxer); ok {
 			if !obj.CommandMode() {
 				handleNavigateKey(e)

--- a/ui_controls.go
+++ b/ui_controls.go
@@ -52,12 +52,6 @@ func handleEditKey() {
 	}
 }
 
-func handleCommentKey() {
-	if obj, ok := currentPage.(TicketCommenter); ok {
-		obj.CommentTicket()
-	}
-}
-
 func handleBackKey() {
 	if obj, ok := currentPage.(GoBacker); ok {
 		obj.GoBack()
@@ -150,8 +144,6 @@ func handleNavigateKey(e ui.Event) {
 		handleRefreshKey()
 	case "E":
 		handleEditKey()
-	case "C":
-		handleCommentKey()
 	case "q":
 		handleBackKey()
 	case "<enter>":

--- a/ui_controls.go
+++ b/ui_controls.go
@@ -133,6 +133,12 @@ func handleParaDownKey() {
 	}
 }
 
+func handleNextSearchKey() {
+	if obj, ok := currentPage.(Searcher); ok {
+		obj.Search()
+	}
+}
+
 func handleNavigateKey(e ui.Event) {
 	key := e.Data.(ui.EvtKbd).KeyStr
 	switch key {
@@ -178,6 +184,8 @@ func handleNavigateKey(e ui.Event) {
 		handleCommandKey(e)
 	case "?":
 		handleCommandKey(e)
+	case "n":
+		handleNextSearchKey()
 	}
 }
 

--- a/ui_controls.go
+++ b/ui_controls.go
@@ -6,8 +6,15 @@ import (
 )
 
 func registerKeyboardHandlers() {
-	ui.Handle("/sys/kbd/q", func(ui.Event) {
-		handleBackKey()
+	ui.Handle("/sys/kbd/", func(ev ui.Event) {
+		handleAnyKey(ev)
+	})
+	ui.Handle("/sys/kbd/q", func(ev ui.Event) {
+		if _, ok := currentPage.(PagePager); ok {
+			handleBackKey()
+		} else {
+			handleAnyKey(ev)
+		}
 	})
 	ui.Handle("/sys/kbd/C-r", func(ui.Event) {
 		handleRefreshKey()
@@ -16,21 +23,41 @@ func registerKeyboardHandlers() {
 		ui.Close()
 		os.Exit(0)
 	})
-	ui.Handle("/sys/kbd/Q", func(ui.Event) {
-		ui.Close()
-		os.Exit(0)
+	ui.Handle("/sys/kbd/Q", func(ev ui.Event) {
+		if _, ok := currentPage.(PagePager); ok {
+			ui.Close()
+			os.Exit(0)
+		} else {
+			handleAnyKey(ev)
+		}
 	})
-	ui.Handle("/sys/kbd/}", func(ui.Event) {
-		handleParaDownKey()
+	ui.Handle("/sys/kbd/}", func(ev ui.Event) {
+		if _, ok := currentPage.(PagePager); ok {
+			handleParaDownKey()
+		} else {
+			handleAnyKey(ev)
+		}
 	})
-	ui.Handle("/sys/kbd/{", func(ui.Event) {
-		handleParaUpKey()
+	ui.Handle("/sys/kbd/{", func(ev ui.Event) {
+		if _, ok := currentPage.(PagePager); ok {
+			handleParaUpKey()
+		} else {
+			handleAnyKey(ev)
+		}
 	})
-	ui.Handle("/sys/kbd/j", func(ui.Event) {
-		handleDownKey()
+	ui.Handle("/sys/kbd/j", func(ev ui.Event) {
+		if _, ok := currentPage.(PagePager); ok {
+			handleDownKey()
+		} else {
+			handleAnyKey(ev)
+		}
 	})
-	ui.Handle("/sys/kbd/k", func(ui.Event) {
-		handleUpKey()
+	ui.Handle("/sys/kbd/k", func(ev ui.Event) {
+		if _, ok := currentPage.(PagePager); ok {
+			handleUpKey()
+		} else {
+			handleAnyKey(ev)
+		}
 	})
 	ui.Handle("/sys/kbd/<down>", func(ui.Event) {
 		handleDownKey()
@@ -38,20 +65,40 @@ func registerKeyboardHandlers() {
 	ui.Handle("/sys/kbd/<up>", func(ui.Event) {
 		handleUpKey()
 	})
-	ui.Handle("/sys/kbd/g", func(ui.Event) {
-		handleTopOfPageKey()
+	ui.Handle("/sys/kbd/g", func(ev ui.Event) {
+		if _, ok := currentPage.(PagePager); ok {
+			handleTopOfPageKey()
+		} else {
+			handleAnyKey(ev)
+		}
 	})
-	ui.Handle("/sys/kbd/G", func(ui.Event) {
-		handleBottomOfPageKey()
+	ui.Handle("/sys/kbd/G", func(ev ui.Event) {
+		if _, ok := currentPage.(PagePager); ok {
+			handleBottomOfPageKey()
+		} else {
+			handleAnyKey(ev)
+		}
 	})
-	ui.Handle("/sys/kbd/L", func(ui.Event) {
-		handleLabelViewKey()
+	ui.Handle("/sys/kbd/L", func(ev ui.Event) {
+		if _, ok := currentPage.(PagePager); ok {
+			handleLabelViewKey()
+		} else {
+			handleAnyKey(ev)
+		}
 	})
-	ui.Handle("/sys/kbd/S", func(ui.Event) {
-		handleSortOrderKey()
+	ui.Handle("/sys/kbd/S", func(ev ui.Event) {
+		if _, ok := currentPage.(PagePager); ok {
+			handleSortOrderKey()
+		} else {
+			handleAnyKey(ev)
+		}
 	})
-	ui.Handle("/sys/kbd/<enter>", func(ui.Event) {
-		handleSelectKey()
+	ui.Handle("/sys/kbd/<enter>", func(ev ui.Event) {
+		if _, ok := currentPage.(PagePager); ok {
+			handleSelectKey()
+		} else {
+			handleAnyKey(ev)
+		}
 	})
 	ui.Handle("/sys/kbd/<space>", func(ui.Event) {
 		handlePageDownKey()
@@ -62,11 +109,19 @@ func registerKeyboardHandlers() {
 	ui.Handle("/sys/kbd/C-b", func(ui.Event) {
 		handlePageUpKey()
 	})
-	ui.Handle("/sys/kbd/E", func(ui.Event) {
-		handleEditKey()
+	ui.Handle("/sys/kbd/E", func(ev ui.Event) {
+		if _, ok := currentPage.(PagePager); ok {
+			handleEditKey()
+		} else {
+			handleAnyKey(ev)
+		}
 	})
-	ui.Handle("/sys/kbd/C", func(ui.Event) {
-		handleCommentKey()
+	ui.Handle("/sys/kbd/C", func(ev ui.Event) {
+		if _, ok := currentPage.(PagePager); ok {
+			handleCommentKey()
+		} else {
+			handleAnyKey(ev)
+		}
 	})
 	ui.Handle("/sys/wnd/resize", func(ui.Event) {
 		handleResize()
@@ -183,6 +238,32 @@ func handleParaUpKey() {
 func handleParaDownKey() {
 	if obj, ok := currentPage.(PagePager); ok {
 		obj.NextPara()
+		obj.Update()
+	}
+}
+
+func handleAnyKey(e ui.Event) {
+	if obj, ok := currentPage.(EditPager); ok {
+		key := e.Data.(ui.EvtKbd).KeyStr
+		var str string
+		switch {
+		case len(key) == 1:
+			str = key
+		case key == "<enter>":
+			str = "\n"
+		case key == "<space>":
+			log.Noticef("space!")
+			str = ` `
+		case key == "<backspace>" || key == "C-8":
+			log.Noticef("backspace!")
+			obj.DeleteRuneBackward()
+			obj.Update()
+			return
+		default:
+			return
+		}
+		r := decodeTermuiKbdStringToRune(str)
+		obj.InsertRune(r)
 		obj.Update()
 	}
 }

--- a/utils.go
+++ b/utils.go
@@ -40,15 +40,6 @@ func runJiraCmdEdit(ticketId string) {
 	os.Exit(0)
 }
 
-func runJiraCmdComment(ticketId string) {
-	opts := getJiraOpts()
-	c := jira.New(opts)
-	ui.Close()
-	c.CmdComment(ticketId)
-	log.Notice("Regrettably, need to exit after comment. See https://github.com/mikepea/go-jira-ui/issues/8")
-	os.Exit(0)
-}
-
 func runJiraCmdCommentNoEditor(ticketId string, comment string) {
 	opts := getJiraOpts()
 	opts["comment"] = comment

--- a/utils.go
+++ b/utils.go
@@ -49,6 +49,13 @@ func runJiraCmdComment(ticketId string) {
 	os.Exit(0)
 }
 
+func runJiraCmdCommentNoEditor(ticketId string, comment string) {
+	opts := getJiraOpts()
+	opts["comment"] = comment
+	c := jira.New(opts)
+	c.CmdComment(ticketId)
+}
+
 func runJiraCmdLabels(ticketId string, action string, labels []string) {
 	opts := getJiraOpts()
 	c := jira.New(opts)

--- a/utils.go
+++ b/utils.go
@@ -62,6 +62,12 @@ func runJiraCmdAssign(ticketId string, user string) {
 	c.CmdAssign(ticketId, user)
 }
 
+func runJiraCmdWatch(ticketId string) {
+	opts := getJiraOpts()
+	c := jira.New(opts)
+	c.CmdWatch(ticketId)
+}
+
 func runJiraCmdLabels(ticketId string, action string, labels []string) {
 	opts := getJiraOpts()
 	c := jira.New(opts)

--- a/utils.go
+++ b/utils.go
@@ -49,6 +49,15 @@ func runJiraCmdComment(ticketId string) {
 	os.Exit(0)
 }
 
+func runJiraCmdLabels(ticketId string, action string, labels []string) {
+	opts := getJiraOpts()
+	c := jira.New(opts)
+	err := c.CmdLabels(action, ticketId, labels)
+	if err != nil {
+		log.Errorf("Error writing labels: %q", err)
+	}
+}
+
 func findTicketIdInString(line string) string {
 	re := regexp.MustCompile(`[A-Z]{3,12}-[0-9]{1,6}`)
 	return strings.TrimSpace(re.FindString(line))

--- a/utils.go
+++ b/utils.go
@@ -56,6 +56,12 @@ func runJiraCmdCommentNoEditor(ticketId string, comment string) {
 	c.CmdComment(ticketId)
 }
 
+func runJiraCmdAssign(ticketId string, user string) {
+	opts := getJiraOpts()
+	c := jira.New(opts)
+	c.CmdAssign(ticketId, user)
+}
+
 func runJiraCmdLabels(ticketId string, action string, labels []string) {
 	opts := getJiraOpts()
 	c := jira.New(opts)


### PR DESCRIPTION
This branch adds 'input' support, and associated operations:

* ':' style commands a'la vim - :label :comment :take :watch :assign
* '/' and '?' style search commands

This is via a `CommandBar`  and `CommandBarFragment` implementation, sitting at the bottom of the page.

A `StatusBarFragment` is also present, but is as yet unused. Mostly there to make it look like vim/tig at the moment, but it will be handy.

This involved some chunky rework of ui_controls.go, and minor changes to nagivation.