### PR TITLE
Add :view {ticket} and :query {JQL} commands; fix display bug.

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Actions:
     W            - Unwatch the selected ticket
     v            - Vote for the selected ticket
     V            - Remove vote on the selected ticket
+    h            - show help page
 
 Commands (like vim/tig/less):
 
@@ -77,6 +78,9 @@ Commands (like vim/tig/less):
     :watch [add/remove] [watcher]  - watch ticket (optionally as a different user)
     :vote                          - vote for the selected ticket
     :unvote                        - remove vote for the selected ticket
+    :view {ticket}                 - display {ticket}
+    :query {JQL}                   - display results of JQL
+    :help                          - show help page
     :<up>                          - select previous command
     :quit or :q                    - quit
 

--- a/base_list_page.go
+++ b/base_list_page.go
@@ -146,7 +146,7 @@ func (p *BaseListPage) markActiveLine() {
 }
 
 func (p *BaseListPage) Id() string {
-	return "X"
+	return fmt.Sprintf("BaseListPage(%p)", p)
 }
 
 func (p *BaseListPage) Update() {

--- a/command_bar.go
+++ b/command_bar.go
@@ -14,8 +14,11 @@ func (p *CommandBar) Submit() {
 	if obj, ok := currentPage.(CommandBoxer); ok {
 		obj.SetCommandMode(false)
 		obj.ExecuteCommand()
-		obj.Update()
 		p.previousCommands = append(p.previousCommands, string(p.text))
+	}
+	// currentPage may have changed
+	if obj, ok := currentPage.(CommandBoxer); ok {
+		obj.Update()
 	}
 }
 

--- a/command_bar_fragment.go
+++ b/command_bar_fragment.go
@@ -51,6 +51,8 @@ func handleCommand(command string) {
 		handleQuit()
 	case action == "label" || action == "labels":
 		handleLabelCommand(args)
+	case action == "help":
+		handleHelp()
 	case action == "watch":
 		handleWatchCommand(args)
 	case action == "vote":
@@ -67,6 +69,15 @@ func handleCommand(command string) {
 	case action == "comment":
 		if len(command) > 10 {
 			handleCommentCommand(string(command[9:]))
+		}
+	case action == "query":
+		n := len(":query ")
+		if len(command) > n {
+			handleQueryCommand(string(command[(n - 1):]))
+		}
+	case action == "view":
+		if len(args) > 0 {
+			handleViewCommand(args[0])
 		}
 	}
 }
@@ -123,6 +134,29 @@ func handleAssignCommand(user string) {
 		runJiraCmdAssign(ticketId, user)
 		obj.Refresh()
 	}
+}
+
+func handleViewCommand(ticket string) {
+	log.Debugf("handleViewCommand: ticket %s", ticket)
+	if ticket == "" {
+		return
+	}
+	q := new(TicketShowPage)
+	q.TicketId = ticket
+	currentPage = q
+	changePage()
+}
+
+func handleQueryCommand(query string) {
+	log.Debugf("handleQueryCommand: query %q", query)
+	if query == "" {
+		return
+	}
+	q := new(TicketListPage)
+	q.ActiveQuery.Name = "adhoc query"
+	q.ActiveQuery.JQL = query
+	currentPage = q
+	changePage()
 }
 
 func handleVoteCommand(up bool) {

--- a/query_list_page.go
+++ b/query_list_page.go
@@ -154,6 +154,7 @@ func (p *QueryPage) SelectItem() {
 
 func (p *QueryPage) Update() {
 	ls := p.uiList
+	log.Debugf("QueryPage.Update(): self:        %s (%p), ls: (%p)", p.Id(), p, ls)
 	p.markActiveLine()
 	ls.Items = p.displayLines[p.firstDisplayLine:]
 	ui.Render(ls)
@@ -170,6 +171,8 @@ func (p *QueryPage) Refresh() {
 }
 
 func (p *QueryPage) Create() {
+	log.Debugf("QueryPage.Create(): self:        %s (%p)", p.Id(), p)
+	log.Debugf("QueryPage.Create(): currentPage: %s (%p)", currentPage.Id(), currentPage)
 	ui.Clear()
 	ls := ui.NewList()
 	p.uiList = ls

--- a/templates.go
+++ b/templates.go
@@ -59,6 +59,7 @@ subtasks:
     V            - Remove vote on the selected ticket
     w            - Watch the selected ticket
     W            - Unwatch the selected ticket
+    h            - show help page
 
 [Commands (a'la vim/tig):](fg-blue)
 
@@ -71,6 +72,9 @@ subtasks:
     :vote                          - vote for the selected ticket
     :unvote                        - remove vote for the selected ticket
     :watch [add/remove] [watcher]  - watch ticket (optionally as a different user)
+    :view {ticket}                 - display {ticket}
+    :query {JQL}                   - display results of JQL
+    :help                          - show help page
     :<up>                          - select previous command
     :quit or :q                    - quit
 

--- a/ticket_list_page.go
+++ b/ticket_list_page.go
@@ -66,6 +66,7 @@ func (p *TicketListPage) EditTicket() {
 
 func (p *TicketListPage) Update() {
 	ls := p.uiList
+	log.Debugf("TicketListPage.Update(): self:        %s (%p), ls: (%p)", p.Id(), p, ls)
 	p.markActiveLine()
 	ls.Items = p.displayLines[p.firstDisplayLine:]
 	ui.Render(ls)
@@ -83,6 +84,8 @@ func (p *TicketListPage) Refresh() {
 }
 
 func (p *TicketListPage) Create() {
+	log.Debugf("TicketListPage.Create(): self:        %s (%p)", p.Id(), p)
+	log.Debugf("TicketListPage.Create(): currentPage: %s (%p)", currentPage.Id(), currentPage)
 	ui.Clear()
 	ls := ui.NewList()
 	p.uiList = ls

--- a/ticket_show_page.go
+++ b/ticket_show_page.go
@@ -141,6 +141,7 @@ func (p *TicketShowPage) Refresh() {
 
 func (p *TicketShowPage) Update() {
 	ls := p.uiList
+	log.Debugf("TicketShowPage.Update(): self:        %s (%p), ls: (%p)", p.Id(), p, ls)
 	p.markActiveLine()
 	ls.Items = p.displayLines[p.firstDisplayLine:]
 	ui.Render(ls)
@@ -149,6 +150,8 @@ func (p *TicketShowPage) Update() {
 }
 
 func (p *TicketShowPage) Create() {
+	log.Debugf("TicketShowPage.Create(): self:        %s (%p)", p.Id(), p)
+	log.Debugf("TicketShowPage.Create(): currentPage: %s (%p)", currentPage.Id(), currentPage)
 	p.opts = getJiraOpts()
 	if p.TicketId == "" {
 		p.TicketId = ticketListPage.GetSelectedTicketId()


### PR DESCRIPTION
This adds :view and :query commands, to view adhoc tickets and JQL as needed.

   :view {ticket-id}  -- opens ticket up in TicketShow page
   :query {JQL}       -- opens up TicketList page with custom query

Also adds :help

It highlighted a bug in the CommandBox.Submit() func, as in these cases the
ExecuteCommand call is updating CurrentPage, so we need to refresh our idea of it
when doing the type check.