### PR TITLE
Fixes #19: Command history improvements

### DIFF
--- a/command_bar.go
+++ b/command_bar.go
@@ -87,6 +87,36 @@ func (p *CommandBar) PreviousCommand() {
 	}
 }
 
+func (p *CommandBar) NextCommand() {
+	if obj, ok := currentPage.(CommandBoxer); ok {
+		ct := p.commandType
+		switch {
+		case (ct == ':'):
+			if len(p.commandHistory) == 0 {
+				return
+			}
+			p.text = []byte(string(p.commandType) + p.commandHistory[p.commandHistoryIndex])
+			if p.commandHistoryIndex < len(p.commandHistory)-1 {
+				p.commandHistoryIndex = p.commandHistoryIndex + 1
+			} else {
+				p.resetCommandIndex()
+			}
+		case (ct == '/' || ct == '?'):
+			if len(p.searchHistory) == 0 {
+				return
+			}
+			p.text = []byte(string(p.commandType) + p.searchHistory[p.searchHistoryIndex])
+			if p.searchHistoryIndex < len(p.commandHistory)-1 {
+				p.searchHistoryIndex = p.searchHistoryIndex + 1
+			} else {
+				p.resetSearchIndex()
+			}
+		}
+		p.MoveCursorToEnd()
+		obj.Update()
+	}
+}
+
 func (p *CommandBar) Reset() {
 	p.text = []byte(``)
 	p.line_voffset = 0

--- a/command_bar.go
+++ b/command_bar.go
@@ -22,20 +22,30 @@ func (p *CommandBar) resetCommandIndex() {
 	p.previousCommandIndex = len(p.previousCommands) - 1
 }
 
+func addCommandIfNotSameAsLast(new string, history *[]string) {
+	log.Noticef("addCommandIfNotSameAsLast: got %s", new)
+	l := len(*history)
+	if l > 0 && new == (*history)[l-1] {
+		return
+	} else {
+		log.Noticef("addCommandIfNotSameAsLast: Adding %s", new)
+		*history = append(*history, new)
+	}
+}
+
 func (p *CommandBar) Submit() {
 	if obj, ok := currentPage.(CommandBoxer); ok {
 		obj.SetCommandMode(false)
 		obj.ExecuteCommand()
 		if len(p.text) > 1 {
-			switch p.text[0] {
-			case ':':
-				p.previousCommands = append(p.previousCommands, string(p.text[1:]))
+			ct := p.text[0]
+			cb := string(p.text[1:])
+			switch {
+			case ct == ':':
+				addCommandIfNotSameAsLast(cb, &p.previousCommands)
 				p.resetCommandIndex()
-			case '/':
-				p.previousSearches = append(p.previousSearches, string(p.text[1:]))
-				p.resetSearchIndex()
-			case '?':
-				p.previousSearches = append(p.previousSearches, string(p.text[1:]))
+			case (ct == '/' || ct == '?'):
+				addCommandIfNotSameAsLast(cb, &p.previousSearches)
 				p.resetSearchIndex()
 			}
 		}

--- a/command_bar.go
+++ b/command_bar.go
@@ -7,19 +7,19 @@ import (
 type CommandBar struct {
 	uiList *ui.List
 	EditBox
-	commandType          byte
-	previousCommandIndex int
-	previousSearchIndex  int
-	previousCommands     []string
-	previousSearches     []string
+	commandType         byte
+	commandHistoryIndex int
+	searchHistoryIndex  int
+	commandHistory      []string
+	searchHistory       []string
 }
 
 func (p *CommandBar) resetSearchIndex() {
-	p.previousSearchIndex = len(p.previousSearches) - 1
+	p.searchHistoryIndex = len(p.searchHistory) - 1
 }
 
 func (p *CommandBar) resetCommandIndex() {
-	p.previousCommandIndex = len(p.previousCommands) - 1
+	p.commandHistoryIndex = len(p.commandHistory) - 1
 }
 
 func addCommandIfNotSameAsLast(new string, history *[]string) {
@@ -42,10 +42,10 @@ func (p *CommandBar) Submit() {
 			cb := string(p.text[1:])
 			switch {
 			case ct == ':':
-				addCommandIfNotSameAsLast(cb, &p.previousCommands)
+				addCommandIfNotSameAsLast(cb, &p.commandHistory)
 				p.resetCommandIndex()
 			case (ct == '/' || ct == '?'):
-				addCommandIfNotSameAsLast(cb, &p.previousSearches)
+				addCommandIfNotSameAsLast(cb, &p.searchHistory)
 				p.resetSearchIndex()
 			}
 		}
@@ -62,22 +62,22 @@ func (p *CommandBar) PreviousCommand() {
 		ct := p.commandType
 		switch {
 		case (ct == ':'):
-			if len(p.previousCommands) == 0 {
+			if len(p.commandHistory) == 0 {
 				return
 			}
-			p.text = []byte(string(p.commandType) + p.previousCommands[p.previousCommandIndex])
-			if p.previousCommandIndex > 0 {
-				p.previousCommandIndex = p.previousCommandIndex - 1
+			p.text = []byte(string(p.commandType) + p.commandHistory[p.commandHistoryIndex])
+			if p.commandHistoryIndex > 0 {
+				p.commandHistoryIndex = p.commandHistoryIndex - 1
 			} else {
 				p.resetCommandIndex()
 			}
 		case (ct == '/' || ct == '?'):
-			if len(p.previousSearches) == 0 {
+			if len(p.searchHistory) == 0 {
 				return
 			}
-			p.text = []byte(string(p.commandType) + p.previousSearches[p.previousSearchIndex])
-			if p.previousSearchIndex > 0 {
-				p.previousSearchIndex = p.previousSearchIndex - 1
+			p.text = []byte(string(p.commandType) + p.searchHistory[p.searchHistoryIndex])
+			if p.searchHistoryIndex > 0 {
+				p.searchHistoryIndex = p.searchHistoryIndex - 1
 			} else {
 				p.resetSearchIndex()
 			}

--- a/editbox.go
+++ b/editbox.go
@@ -89,6 +89,10 @@ func (eb *EditBox) MoveCursorTo(boffset int) {
 	eb.cursor_voffset, eb.cursor_coffset = voffset_coffset(eb.text, boffset)
 }
 
+func (eb *EditBox) MoveCursorToEnd() {
+	eb.MoveCursorTo(len(eb.text))
+}
+
 func rune_advance_len(r rune, pos int) int {
 	if r == '\t' {
 		return tabstop_length - pos%tabstop_length

--- a/help_page.go
+++ b/help_page.go
@@ -64,7 +64,7 @@ func (p *HelpPage) Create() {
 		p.statusBar = new(StatusBar)
 	}
 	if p.commandBar == nil {
-		p.commandBar = new(CommandBar)
+		p.commandBar = commandBar
 	}
 	if len(p.cachedResults) == 0 {
 		p.cachedResults = HelpTextAsStrings(nil, "jira_ui_help")

--- a/label_list_page.go
+++ b/label_list_page.go
@@ -94,7 +94,7 @@ func (p *LabelListPage) Create() {
 		p.statusBar = new(StatusBar)
 	}
 	if p.commandBar == nil {
-		p.commandBar = new(CommandBar)
+		p.commandBar = commandBar
 	}
 	queryName := p.ActiveQuery.Name
 	queryJQL := p.ActiveQuery.JQL

--- a/query_list_page.go
+++ b/query_list_page.go
@@ -180,7 +180,7 @@ func (p *QueryPage) Create() {
 		p.statusBar = new(StatusBar)
 	}
 	if p.commandBar == nil {
-		p.commandBar = new(CommandBar)
+		p.commandBar = commandBar
 	}
 	p.cachedResults = getQueries()
 	p.displayLines = make([]string, len(p.cachedResults))

--- a/run.go
+++ b/run.go
@@ -83,6 +83,7 @@ var ticketListPage *TicketListPage
 var labelListPage *LabelListPage
 var sortOrderPage *SortOrderPage
 var passwordInputBox *PasswordInputBox
+var commandBar *CommandBar
 
 func changePage() {
 	switch currentPage.(type) {
@@ -234,6 +235,7 @@ Query Options:
 	ticketQueryPage = new(QueryPage)
 	passwordInputBox = new(PasswordInputBox)
 	helpPage = new(HelpPage)
+	commandBar = new(CommandBar)
 
 	switch command {
 	case "list":

--- a/ticket_list_page.go
+++ b/ticket_list_page.go
@@ -93,7 +93,7 @@ func (p *TicketListPage) Create() {
 		p.statusBar = new(StatusBar)
 	}
 	if p.commandBar == nil {
-		p.commandBar = new(CommandBar)
+		p.commandBar = commandBar
 	}
 	query := p.ActiveQuery.JQL
 	if sort := p.ActiveSort.JQL; sort != "" {

--- a/ticket_show_page.go
+++ b/ticket_show_page.go
@@ -169,7 +169,7 @@ func (p *TicketShowPage) Create() {
 		p.statusBar = new(StatusBar)
 	}
 	if p.commandBar == nil {
-		p.commandBar = new(CommandBar)
+		p.commandBar = commandBar
 	}
 	p.uiList = ls
 	if p.Template == "" {

--- a/ui_controls.go
+++ b/ui_controls.go
@@ -259,6 +259,9 @@ func handleAnyKey(e ui.Event) {
 		} else if key == "<up>" {
 			cb.PreviousCommand()
 			return
+		} else if key == "<down>" {
+			cb.NextCommand()
+			return
 		} else {
 			handleEditBoxKey(cb, key)
 			return


### PR DESCRIPTION

Now uses a single CommandBar instance, to ensure we share history across pages.

Treat search and action commands as different histories.

Store an actual history too. Currently unlimited, might need to restrict that to 100 or something.

Don't store repeat commands.

Implement <down> as well.