### PR TITLE
allow 2-character project names for findTicketIdInString

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -85,7 +85,7 @@ func runJiraCmdLabels(ticketId string, action string, labels []string) {
 }
 
 func findTicketIdInString(line string) string {
-	re := regexp.MustCompile(`[A-Z]{3,12}-[0-9]{1,6}`)
+	re := regexp.MustCompile(`[A-Z]{2,12}-[0-9]{1,6}`)
 	return strings.TrimSpace(re.FindString(line))
 }
 

--- a/utils_test.go
+++ b/utils_test.go
@@ -46,8 +46,8 @@ func TestFindTicketIdInString(t *testing.T) {
 		t.Fatalf("expected %q, got %q", "", match)
 	}
 	match = findTicketIdInString("  wibble: xxBL-1[Done]  ")
-	if match != "" {
-		t.Fatalf("expected %q, got %q", "", match)
+	if match != "BL-1" {
+		t.Fatalf("expected %q, got %q", "BL-1", match)
 	}
 	match = findTicketIdInString("  wibble: xxBLAH-1[Done]  ")
 	if match != "BLAH-1" {


### PR DESCRIPTION
2-character project names are valid.  We have projects like AB, TQ, etc; currently, you can load issues directly with `jira-ui <issue>`, but trying to load those issues from a search fails because it can't retrieve the ID.

The modified test fails without the change and passes with it.