### PR TITLE
alllow ranking issues (move up/down in priority) in list view

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ useful:
 Actions:
 
     <enter>      - select query/ticket
+    r            - mark ticket for ranking (use naviation to change rank, <enter> to submit)
     L            - Label view (query results page only)
     E            - Edit ticket
     S            - Select sort order (query results page only)

--- a/run.go
+++ b/run.go
@@ -83,6 +83,10 @@ type Navigable interface {
 	Id() string
 }
 
+type RankSelector interface {
+	MarkItemForRanking()
+}
+
 var currentPage Navigable
 var previousPages []Navigable
 

--- a/scrollablelist.go
+++ b/scrollablelist.go
@@ -118,6 +118,30 @@ func (sl *ScrollableList) ScrollDown() {
 	}
 }
 
+// Swap current row with previous row, then move
+// cursor to previous row
+func (sl *ScrollableList) MoveUp(n int) {
+	if sl.Cursor >= n {
+		cur := sl.Items[sl.Cursor]
+		up := sl.Items[sl.Cursor - n]
+		sl.Items[sl.Cursor] = up
+		sl.Items[sl.Cursor - n] = cur
+	}
+	sl.CursorUpLines(n)
+}
+
+// Swap current row with next row, then move
+// cursor to next row
+func (sl *ScrollableList) MoveDown(n int) {
+	if sl.Cursor < len(sl.Items) - n {
+		cur := sl.Items[sl.Cursor]
+		down := sl.Items[sl.Cursor + n]
+		sl.Items[sl.Cursor] = down
+		sl.Items[sl.Cursor + n] = cur
+	}
+	sl.CursorDownLines(n)
+}
+
 // Move the cursor down one row; moving the cursor out of the window will cause
 // scrolling.
 func (sl *ScrollableList) CursorDown() {

--- a/sort_order_page.go
+++ b/sort_order_page.go
@@ -21,6 +21,7 @@ var baseSorts = []Sort{
 	Sort{"created, oldest first", "ORDER BY created ASC"},
 	Sort{"updated, newest first", "ORDER BY updated DESC"},
 	Sort{"updated, oldest first", "ORDER BY updated ASC"},
+	Sort{"rank", "ORDER BY Rank DESC"},
 	Sort{"---", ""}, // no-op line in UI
 }
 

--- a/ticket_list_page.go
+++ b/ticket_list_page.go
@@ -70,10 +70,10 @@ func (p *TicketListPage) NextLine(n int) {
 func (p *TicketListPage) SelectItem() {
 	if p.RankingTicketId != "" {
 		log.Debugf("Setting Rank for %s", p.RankingTicketId)
-		order := jira.RANKBEFORE
+		order := jira.RANKAFTER
 		var targetId string
 		if p.uiList.Cursor == 0 {
-			order = jira.RANKAFTER
+			order = jira.RANKBEFORE
 			targetId = findTicketIdInString(p.cachedResults[p.uiList.Cursor+1])
 		} else {
 			targetId = findTicketIdInString(p.cachedResults[p.uiList.Cursor-1])

--- a/ui_controls.go
+++ b/ui_controls.go
@@ -80,6 +80,12 @@ func handleSelectKey() {
 	}
 }
 
+func handleMarkTicketKey() {
+	if obj, ok := currentPage.(RankSelector); ok {
+		obj.MarkItemForRanking()
+	}
+}
+
 func handleTopOfPageKey() {
 	if obj, ok := currentPage.(PagePager); ok {
 		obj.TopOfPage()
@@ -221,6 +227,8 @@ func handleNavigateKey(e ui.Event) {
 		handlePrevTicketKey()
 	case "h":
 		handleHelp()
+	case "r":
+		handleMarkTicketKey()
 	}
 }
 

--- a/utils.go
+++ b/utils.go
@@ -132,6 +132,15 @@ func runJiraCmdLabels(ticketId string, action string, labels []string) {
 	}
 }
 
+func runJiraCmdRank(ticketId, targetId string, order jira.RankOrder) {
+	opts := getJiraOpts()
+	c := jira.New(opts)
+	err := c.RankIssue(ticketId, targetId, order)
+	if err != nil {
+		log.Errorf("Error modifying issue rank: %q", err)
+	}
+}
+
 func findTicketIdInString(line string) string {
 	re := regexp.MustCompile(`[A-Z]{2,12}-[0-9]{1,6}`)
 	return strings.TrimSpace(re.FindString(line))


### PR DESCRIPTION
hey @mikepea,

I just added some basic ability to rank issues in a backlog via `go-jira`.  I thought it would be more useful/user-friendly to have this ability in your ui so I could just us the arrow key move the issues around.  I also added a build-in sort order of "rank" to allow sorting by issue rank  (I wonder if this should be the default).

Let me know if you have any questions or would like some changes.

Thanks!
-Cory