### PR TITLE
Fix find ticket id in string too long

### DIFF
--- a/run.go
+++ b/run.go
@@ -211,7 +211,7 @@ Query Options:
 	})
 
 	if err := op.ProcessAll(os.Args[1:]); err != nil {
-		log.Error("%s", err)
+		log.Errorf("%s", err)
 		usage(false)
 	}
 	args := op.Args
@@ -238,7 +238,7 @@ Query Options:
 
 	requireArgs := func(count int) {
 		if len(args) < count {
-			log.Error("Not enough arguments. %d required, %d provided", count, len(args))
+			log.Errorf("Not enough arguments. %d required, %d provided", count, len(args))
 			usage(false)
 		}
 	}
@@ -265,7 +265,7 @@ Query Options:
 	switch command {
 	case "list":
 		if query := cliOpts["query"]; query == nil {
-			log.Error("Must supply a --query option to %q", command)
+			log.Errorf("Must supply a --query option to %q", command)
 			os.Exit(1)
 		} else {
 			p := new(TicketListPage)
@@ -283,7 +283,7 @@ Query Options:
 	case "password":
 		currentPage = new(PasswordInputBox)
 	default:
-		log.Error("Unknown command %s", command)
+		log.Errorf("Unknown command %s", command)
 		os.Exit(1)
 	}
 

--- a/utils.go
+++ b/utils.go
@@ -143,6 +143,12 @@ func runJiraCmdRank(ticketId, targetId string, order jira.RankOrder) {
 
 func findTicketIdInString(line string) string {
 	re := regexp.MustCompile(`[A-Z]{2,12}-[0-9]{1,6}`)
+	re_too_long := regexp.MustCompile(`[A-Z]{13}-[0-9]{1,6}`)
+
+	if re_too_long.MatchString(line) {
+		return ""
+	}
+
 	return strings.TrimSpace(re.FindString(line))
 }
 


### PR DESCRIPTION
Add a regex to check for too long project names, but i'm not sure if it the right way