### PR TITLE
changed go-jira import to old api

### DIFF
--- a/ticket_list_page.go
+++ b/ticket_list_page.go
@@ -5,7 +5,7 @@ import (
 	"regexp"
 
 	ui "github.com/gizak/termui"
-	"github.com/Netflix-Skunkworks/go-jira"
+	"gopkg.in/Netflix-Skunkworks/go-jira.v0"
 )
 
 type TicketListPage struct {

--- a/utils.go
+++ b/utils.go
@@ -9,7 +9,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/Netflix-Skunkworks/go-jira"
+	"gopkg.in/Netflix-Skunkworks/go-jira.v0"
 	ui "github.com/gizak/termui"
 	"github.com/mitchellh/go-wordwrap"
 	"gopkg.in/coryb/yaml.v2"


### PR DESCRIPTION
Had to use the old api to build the project.

> If you have code that depends on the old apis, you can still use them with this import:
> import "gopkg.in/Netflix-Skunkworks/go-jira.v0"

> [https://github.com/Netflix-Skunkworks/go-jira]